### PR TITLE
Feat: added a drag bar on top for easy drag on macOS.

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:window:allow-set-size",
     "core:window:allow-set-min-size",
+    "core:window:allow-start-dragging",
     "opener:default",
     "dialog:default"
   ]

--- a/src/App.css
+++ b/src/App.css
@@ -1,11 +1,21 @@
-@import url('https://fonts.googleapis.com/css2?family=Google+Sans:ital,opsz,wght@0,17..18,400..700;1,17..18,400..700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Google+Sans:ital,opsz,wght@0,17..18,400..700;1,17..18,400..700&display=swap");
 
-* { margin: 0; padding: 0; box-sizing: border-box; user-select: none; -webkit-user-select: none; }
-input, textarea { user-select: text; -webkit-user-select: text; }
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  user-select: none;
+  -webkit-user-select: none;
+}
+input,
+textarea {
+  user-select: text;
+  -webkit-user-select: text;
+}
 
 :root {
-  --font: 'Google Sans', -apple-system, sans-serif;
-  --mono: 'Google Sans Mono', monospace;
+  --font: "Google Sans", -apple-system, sans-serif;
+  --mono: "Google Sans Mono", monospace;
 }
 
 [data-theme="dark"] {
@@ -19,7 +29,7 @@ input, textarea { user-select: text; -webkit-user-select: text; }
   --text: #fafafa;
   --text-2: #a1a1aa;
   --text-3: #52525b;
-  --accent: #86D100;
+  --accent: #86d100;
   --accent-hover: #76b800;
   --accent-glow: rgba(134, 209, 0, 0.12);
   --accent-glow-strong: rgba(134, 209, 0, 0.25);
@@ -31,7 +41,11 @@ input, textarea { user-select: text; -webkit-user-select: text; }
   --shadow: none;
   --canvas-bg: #000;
   --card-shadow: none;
-  --glow: radial-gradient(600px circle at var(--mx, 50%) var(--my, 50%), rgba(134,209,0,0.04), transparent 40%);
+  --glow: radial-gradient(
+    600px circle at var(--mx, 50%) var(--my, 50%),
+    rgba(134, 209, 0, 0.04),
+    transparent 40%
+  );
 }
 
 [data-theme="light"] {
@@ -45,7 +59,7 @@ input, textarea { user-select: text; -webkit-user-select: text; }
   --text: #09090b;
   --text-2: #71717a;
   --text-3: #a1a1aa;
-  --accent: #86D100;
+  --accent: #86d100;
   --accent-hover: #76b800;
   --accent-glow: rgba(134, 209, 0, 0.08);
   --accent-glow-strong: rgba(134, 209, 0, 0.15);
@@ -75,31 +89,29 @@ body {
   width: 100vw;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
   background: var(--bg);
   background-image: var(--glow);
   position: relative;
   animation: welcome-in 0.6s ease-out;
-  padding-top: 38px;
 }
 
-.welcome > *:not(.toast-container):not(.window-drag) {
-  -webkit-app-region: no-drag;
+/* ===== DRAG BAR ===== */
+.drag-bar {
+  height: 28px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
 }
 
-.window-drag {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 38px;
-  -webkit-app-region: drag;
+/* ===== TOOLBAR (Welcome Screen) ===== */
+.toolbar {
+  height: 44px;
   background: var(--surface);
   border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  flex-shrink: 0;
 }
 
 .toolbar-actions {
@@ -107,7 +119,6 @@ body {
   align-items: center;
   gap: 2px;
   padding-right: 10px;
-  -webkit-app-region: no-drag;
 }
 
 .toolbar-btn {
@@ -137,10 +148,33 @@ body {
   color: var(--accent);
 }
 
+.welcome-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+}
 
-@keyframes welcome-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+.welcome-content .welcome-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.welcome-content .welcome-subtitle {
+  font-size: 14px;
+  color: var(--text-2);
+  margin-bottom: 40px;
+  font-weight: 400;
+}
+
+.welcome-content .device-list {
+  width: 360px;
+  max-width: 90vw;
 }
 
 .welcome-header {
@@ -364,7 +398,10 @@ body {
   border-radius: 6px;
   cursor: pointer;
   opacity: 0.4;
-  transition: opacity 0.15s, color 0.15s, background 0.15s;
+  transition:
+    opacity 0.15s,
+    color 0.15s,
+    background 0.15s;
 }
 
 .device-wifi-toggle svg {
@@ -467,8 +504,14 @@ body {
 }
 
 @keyframes another-in {
-  from { opacity: 0; transform: scale(0.98); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 /* Titlebar */
@@ -477,14 +520,12 @@ body {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 0 10px 0 78px;
+  padding: 0 10px;
   background: var(--surface);
   flex-shrink: 0;
-  -webkit-app-region: drag;
 }
 
 .titlebar > * {
-  -webkit-app-region: no-drag;
 }
 
 .titlebar-info {
@@ -493,7 +534,6 @@ body {
   gap: 1px;
   flex: 1;
   min-width: 0;
-  -webkit-app-region: drag;
   padding: 6px 0;
 }
 
@@ -597,7 +637,10 @@ body {
   background: var(--accent-glow);
 }
 
-.btn-icon svg { width: 16px; height: 16px; }
+.btn-icon svg {
+  width: 16px;
+  height: 16px;
+}
 
 /* Viewport */
 .viewport {
@@ -645,7 +688,9 @@ body {
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .viewport-loading p {
@@ -671,8 +716,14 @@ body {
 }
 
 @keyframes recording-fade-in {
-  from { opacity: 0; transform: translateX(-50%) translateY(8px); }
-  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
 }
 
 .recording-dot {
@@ -685,8 +736,13 @@ body {
 }
 
 @keyframes recording-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
 }
 
 .recording-time {
@@ -766,8 +822,12 @@ body {
 }
 
 @keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .settings-panel {
@@ -788,10 +848,13 @@ body {
 }
 
 @keyframes slide-up {
-  from { transform: translateY(100%); }
-  to { transform: translateY(0); }
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
 }
-
 
 .settings-header {
   padding: 12px 20px;
@@ -828,7 +891,9 @@ body {
   margin-bottom: 12px;
 }
 
-.setting-row:last-child { margin-bottom: 0; }
+.setting-row:last-child {
+  margin-bottom: 0;
+}
 
 .setting-label {
   font-size: 13px;
@@ -845,7 +910,10 @@ body {
   text-align: right;
 }
 
-.preset-btns { display: flex; gap: 6px; }
+.preset-btns {
+  display: flex;
+  gap: 6px;
+}
 
 .preset-btn {
   flex: 1;
@@ -861,7 +929,10 @@ body {
   transition: all 0.15s;
 }
 
-.preset-btn:hover { background: var(--surface-hover); color: var(--text); }
+.preset-btn:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
 
 .preset-btn.active {
   border-color: var(--accent);
@@ -876,7 +947,9 @@ body {
   color: var(--text-3);
 }
 
-.settings-note strong { color: var(--text-2); }
+.settings-note strong {
+  color: var(--text-2);
+}
 
 /* ===== Base UI Select ===== */
 .select-trigger {
@@ -895,7 +968,9 @@ body {
   transition: border-color 0.15s;
 }
 
-.select-trigger:hover { background: var(--surface-hover); }
+.select-trigger:hover {
+  background: var(--surface-hover);
+}
 
 .select-icon {
   width: 14px;
@@ -1047,10 +1122,15 @@ body {
   max-width: 340px;
   text-align: center;
   backdrop-filter: blur(16px);
-  animation: toast-in 0.25s ease-out, toast-out 0.3s ease-in 3.7s forwards;
+  animation:
+    toast-in 0.25s ease-out,
+    toast-out 0.3s ease-in 3.7s forwards;
 }
 
-.toast-error { background: rgba(248, 113, 113, 0.95); color: #fff; }
+.toast-error {
+  background: rgba(248, 113, 113, 0.95);
+  color: #fff;
+}
 
 .toast-info {
   background: var(--surface);
@@ -1060,13 +1140,23 @@ body {
 }
 
 @keyframes toast-in {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes toast-out {
-  from { opacity: 1; }
-  to { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 /* ===== Settings hint ===== */

--- a/src/components/MirrorScreen.tsx
+++ b/src/components/MirrorScreen.tsx
@@ -29,13 +29,18 @@ interface MirrorScreenProps {
   onToggleSettings: () => void;
   onOpenCommandBar: () => void;
   onDisconnect: () => void;
-  onCanvasMouseEvent: (e: React.MouseEvent<HTMLCanvasElement>, action: string) => void;
+  onCanvasMouseEvent: (
+    e: React.MouseEvent<HTMLCanvasElement>,
+    action: string
+  ) => void;
   onWheel: (e: React.WheelEvent<HTMLCanvasElement>) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
 }
 
 function formatTime(seconds: number) {
-  const m = Math.floor(seconds / 60).toString().padStart(2, "0");
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, "0");
   const s = (seconds % 60).toString().padStart(2, "0");
   return `${m}:${s}`;
 }
@@ -73,51 +78,89 @@ export function MirrorScreen({
       if (intervalRef.current) clearInterval(intervalRef.current);
       intervalRef.current = null;
     }
-    return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
   }, [recording]);
 
   useEffect(() => {
     if (macroRecording) {
       setMacroElapsed(0);
-      macroIntervalRef.current = setInterval(() => setMacroElapsed((s) => s + 1), 1000);
+      macroIntervalRef.current = setInterval(
+        () => setMacroElapsed((s) => s + 1),
+        1000
+      );
     } else {
       if (macroIntervalRef.current) clearInterval(macroIntervalRef.current);
       macroIntervalRef.current = null;
     }
-    return () => { if (macroIntervalRef.current) clearInterval(macroIntervalRef.current); };
+    return () => {
+      if (macroIntervalRef.current) clearInterval(macroIntervalRef.current);
+    };
   }, [macroRecording]);
 
   return (
     <div className="another">
-      <div className="titlebar" data-tauri-drag-region>
-        <div className="titlebar-info" data-tauri-drag-region>
-          <span className="titlebar-device">{getDeviceDisplayName(connectedDevice)}</span>
+      <div className="drag-bar" data-tauri-drag-region />
+      <div className="titlebar">
+        <div className="titlebar-info">
+          <span className="titlebar-device">
+            {getDeviceDisplayName(connectedDevice)}
+          </span>
           <span className="titlebar-os">Android</span>
         </div>
 
         <div className="titlebar-group">
-          <button className="titlebar-btn" onClick={() => onPressButton("back")} title="Back">
+          <button
+            className="titlebar-btn"
+            onClick={() => onPressButton("back")}
+            title="Back"
+          >
             <ChevronLeftIcon />
           </button>
-          <button className="titlebar-btn" onClick={() => onPressButton("home")} title="Home">
+          <button
+            className="titlebar-btn"
+            onClick={() => onPressButton("home")}
+            title="Home"
+          >
             <HomeIcon />
           </button>
-          <button className="titlebar-btn" onClick={() => onPressButton("recents")} title="Recents">
+          <button
+            className="titlebar-btn"
+            onClick={() => onPressButton("recents")}
+            title="Recents"
+          >
             <Square2StackIcon />
           </button>
         </div>
 
         <div className="titlebar-group">
-          <button className="titlebar-btn" onClick={onOpenCommandBar} title="Commands (⌘K)">
+          <button
+            className="titlebar-btn"
+            onClick={onOpenCommandBar}
+            title="Commands (⌘K)"
+          >
             <CommandLineIcon />
           </button>
-          <button className="titlebar-btn" onClick={onTakeScreenshot} title="Screenshot">
+          <button
+            className="titlebar-btn"
+            onClick={onTakeScreenshot}
+            title="Screenshot"
+          >
             <CameraIcon />
           </button>
-          <button className="titlebar-btn" onClick={onToggleSettings} title="Settings">
+          <button
+            className="titlebar-btn"
+            onClick={onToggleSettings}
+            title="Settings"
+          >
             <Cog6ToothIcon />
           </button>
-          <button className="titlebar-btn" onClick={onDisconnect} title="Disconnect">
+          <button
+            className="titlebar-btn"
+            onClick={onDisconnect}
+            title="Disconnect"
+          >
             <XMarkIcon />
           </button>
         </div>
@@ -134,10 +177,23 @@ export function MirrorScreen({
             ref={canvasRef}
             width={deviceSize.width}
             height={deviceSize.height}
-            onMouseDown={(e) => { isMouseDown.current = true; onCanvasMouseEvent(e, "down"); }}
-            onMouseMove={(e) => { if (isMouseDown.current) onCanvasMouseEvent(e, "move"); }}
-            onMouseUp={(e) => { isMouseDown.current = false; onCanvasMouseEvent(e, "up"); }}
-            onMouseLeave={(e) => { if (isMouseDown.current) { isMouseDown.current = false; onCanvasMouseEvent(e, "up"); } }}
+            onMouseDown={(e) => {
+              isMouseDown.current = true;
+              onCanvasMouseEvent(e, "down");
+            }}
+            onMouseMove={(e) => {
+              if (isMouseDown.current) onCanvasMouseEvent(e, "move");
+            }}
+            onMouseUp={(e) => {
+              isMouseDown.current = false;
+              onCanvasMouseEvent(e, "up");
+            }}
+            onMouseLeave={(e) => {
+              if (isMouseDown.current) {
+                isMouseDown.current = false;
+                onCanvasMouseEvent(e, "up");
+              }
+            }}
             onWheel={onWheel}
             onContextMenu={(e) => e.preventDefault()}
           />
@@ -156,9 +212,24 @@ export function MirrorScreen({
 
         {macroRecording && (
           <div className="recording-bar macro-recording-bar">
-            <svg width="12" height="12" viewBox="0 0 24 25" fill="none" className="macro-rec-icon">
-              <path d="M11.41 2.068c-.57 0-1.08 0-1.55.17-.1.04-.19.08-.29.12-.46.22-.81.58-1.21.98L3.58 8.148c-.47.47-.88.88-1.11 1.43-.22.54-.22 1.13-.22 1.8v3.47c0 1.78 0 3.22.15 4.35.16 1.17.49 2.16 1.27 2.95.78.78 1.76 1.12 2.93 1.28 1.12.15 2.55.15 4.33.15s3.31 0 4.43-.15c-.49-1.1-1.51-2.09-2.61-2.52-1.66-.65-1.66-3.01 0-3.66 1.16-.46 2.22-1.52 2.67-2.67.66-1.66 3.01-1.66 3.66 0 .16.41.39.81.67 1.17V14.858c0-1.53 0-2.77-.11-3.75-.12-1.02-.37-1.89-.96-2.63-.22-.27-.46-.52-.73-.74-.73-.6-1.6-.85-2.61-.97-1.18-.11-2.4-.11-3.92-.11z" fill="currentColor" opacity="0.5"/>
-              <path fillRule="evenodd" clipRule="evenodd" d="M9.569 2.358c.09-.05.19-.09.29-.12.21-.07.42-.12.65-.14v1.99c0 1.36 0 2.01-.12 2.88-.12.9-.38 1.66-.98 2.26s-1.36.86-2.26.98c-.87.12-1.52.12-2.88.12H2.289c.03-.26.09-.51.18-.75.22-.54.64-.96 1.11-1.43l4.78-4.81c.4-.4.76-.77 1.21-.98zM17.919 23.118c-.24.61-1.09.61-1.33 0l-.04-.1a5.73 5.73 0 00-3.23-3.23l-.11-.04c-.6-.24-.6-1.1 0-1.33l.11-.04a5.73 5.73 0 003.23-3.23l.04-.1c.24-.61 1.09-.61 1.33 0l.04.1a5.73 5.73 0 003.23 3.23l.11.04c.6.24.6 1.1 0 1.33l-.11.04a5.73 5.73 0 00-3.23 3.23l-.04.1z" fill="currentColor"/>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 25"
+              fill="none"
+              className="macro-rec-icon"
+            >
+              <path
+                d="M11.41 2.068c-.57 0-1.08 0-1.55.17-.1.04-.19.08-.29.12-.46.22-.81.58-1.21.98L3.58 8.148c-.47.47-.88.88-1.11 1.43-.22.54-.22 1.13-.22 1.8v3.47c0 1.78 0 3.22.15 4.35.16 1.17.49 2.16 1.27 2.95.78.78 1.76 1.12 2.93 1.28 1.12.15 2.55.15 4.33.15s3.31 0 4.43-.15c-.49-1.1-1.51-2.09-2.61-2.52-1.66-.65-1.66-3.01 0-3.66 1.16-.46 2.22-1.52 2.67-2.67.66-1.66 3.01-1.66 3.66 0 .16.41.39.81.67 1.17V14.858c0-1.53 0-2.77-.11-3.75-.12-1.02-.37-1.89-.96-2.63-.22-.27-.46-.52-.73-.74-.73-.6-1.6-.85-2.61-.97-1.18-.11-2.4-.11-3.92-.11z"
+                fill="currentColor"
+                opacity="0.5"
+              />
+              <path
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M9.569 2.358c.09-.05.19-.09.29-.12.21-.07.42-.12.65-.14v1.99c0 1.36 0 2.01-.12 2.88-.12.9-.38 1.66-.98 2.26s-1.36.86-2.26.98c-.87.12-1.52.12-2.88.12H2.289c.03-.26.09-.51.18-.75.22-.54.64-.96 1.11-1.43l4.78-4.81c.4-.4.76-.77 1.21-.98zM17.919 23.118c-.24.61-1.09.61-1.33 0l-.04-.1a5.73 5.73 0 00-3.23-3.23l-.11-.04c-.6-.24-.6-1.1 0-1.33l.11-.04a5.73 5.73 0 003.23-3.23l.04-.1c.24-.61 1.09-.61 1.33 0l.04.1a5.73 5.73 0 003.23 3.23l.11.04c.6.24.6 1.1 0 1.33l-.11.04a5.73 5.73 0 00-3.23 3.23l-.04.1z"
+                fill="currentColor"
+              />
             </svg>
             <span className="recording-time">{formatTime(macroElapsed)}</span>
             <button className="recording-stop" onClick={onToggleMacroRecording}>

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -13,7 +13,11 @@ import {
 } from "@heroicons/react/24/outline";
 import { Dialog } from "@base-ui-components/react/dialog";
 import type { Device, ThemePreference } from "../types";
-import { getDeviceDisplayName, getDeviceNickname, setDeviceNickname } from "../types";
+import {
+  getDeviceDisplayName,
+  getDeviceNickname,
+  setDeviceNickname,
+} from "../types";
 import appIcon from "../assets/icon.png";
 
 interface WelcomeScreenProps {
@@ -51,13 +55,20 @@ export function WelcomeScreen({
   const [togglingSerial, setTogglingSerial] = useState<string | null>(null);
   const [editingSerial, setEditingSerial] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; device: Device } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    device: Device;
+  } | null>(null);
   const contextMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!contextMenu) return;
     const close = (e: MouseEvent) => {
-      if (contextMenuRef.current && !contextMenuRef.current.contains(e.target as Node)) {
+      if (
+        contextMenuRef.current &&
+        !contextMenuRef.current.contains(e.target as Node)
+      ) {
         setContextMenu(null);
       }
     };
@@ -75,7 +86,9 @@ export function WelcomeScreen({
     if (!wifiAddress.trim()) return;
     setWifiConnecting(true);
     try {
-      const addr = wifiAddress.includes(":") ? wifiAddress : `${wifiAddress}:5555`;
+      const addr = wifiAddress.includes(":")
+        ? wifiAddress
+        : `${wifiAddress}:5555`;
       await invoke("wifi_connect", { address: addr });
       showToast("Device connected via WiFi", "info");
       setWifiAddress("");
@@ -96,14 +109,24 @@ export function WelcomeScreen({
         await invoke("wifi_disconnect", { address: device.serial });
         showToast(`${getDeviceDisplayName(device)} WiFi disconnected`, "info");
       } else if (device.wifi_available) {
-        const ip = await invoke<string | null>("get_device_ip", { serial: device.serial });
+        const ip = await invoke<string | null>("get_device_ip", {
+          serial: device.serial,
+        });
         if (ip) {
           await invoke("wifi_disconnect", { address: `${ip}:5555` });
-          showToast(`${getDeviceDisplayName(device)} WiFi disconnected`, "info");
+          showToast(
+            `${getDeviceDisplayName(device)} WiFi disconnected`,
+            "info"
+          );
         }
       } else {
-        const addr = await invoke<string>("wifi_enable", { serial: device.serial });
-        showToast(`${getDeviceDisplayName(device)} now available at ${addr}`, "info");
+        const addr = await invoke<string>("wifi_enable", {
+          serial: device.serial,
+        });
+        showToast(
+          `${getDeviceDisplayName(device)} now available at ${addr}`,
+          "info"
+        );
       }
       onRefreshDevices();
     } catch (e) {
@@ -115,93 +138,146 @@ export function WelcomeScreen({
 
   return (
     <div className="welcome">
-      <div className="window-drag" data-tauri-drag-region>
+      <div className="drag-bar" data-tauri-drag-region />
+      <div className="toolbar">
         <div className="toolbar-actions">
-          <button className="toolbar-btn" onClick={onCycleTheme} title={themePref === "light" ? "Light" : themePref === "dark" ? "Dark" : "System"}>
-            {themePref === "light" ? <SunIcon /> : themePref === "dark" ? <MoonIcon /> : <ComputerDesktopIcon />}
+          <button
+            className="toolbar-btn"
+            onClick={onCycleTheme}
+            title={
+              themePref === "light"
+                ? "Light"
+                : themePref === "dark"
+                  ? "Dark"
+                  : "System"
+            }
+          >
+            {themePref === "light" ? (
+              <SunIcon />
+            ) : themePref === "dark" ? (
+              <MoonIcon />
+            ) : (
+              <ComputerDesktopIcon />
+            )}
           </button>
-          <button className="toolbar-btn" onClick={() => setShowWifiDialog(true)} title="Connect via WiFi">
+          <button
+            className="toolbar-btn"
+            onClick={() => setShowWifiDialog(true)}
+            title="Connect via WiFi"
+          >
             <WifiIcon />
           </button>
-          <button className="toolbar-btn" onClick={onOpenSettings} title="Settings">
+          <button
+            className="toolbar-btn"
+            onClick={onOpenSettings}
+            title="Settings"
+          >
             <Cog6ToothIcon />
           </button>
         </div>
       </div>
-      <div className="welcome-header">
-        <img src={appIcon} alt="Another" className="welcome-logo" />
-        <h1 className="welcome-title">Another</h1>
-      </div>
-      <p className="welcome-subtitle">Android screen mirroring and control</p>
-
-      <div className="device-list">
-        <div className="device-list-header">
-          <span className="device-list-title">
-            {devices.length > 0 ? `${devices.length} device${devices.length > 1 ? "s" : ""} found` : "Searching..."}
-          </span>
-          <button className="device-list-refresh" onClick={onRefreshDevices}>
-            <ArrowPathIcon /> Refresh
-          </button>
+      <div className="welcome-content">
+        <div className="welcome-header">
+          <img src={appIcon} alt="Another" className="welcome-logo" />
+          <h1 className="welcome-title">Another</h1>
         </div>
+        <p className="welcome-subtitle">Android screen mirroring and control</p>
 
-        {devices.length === 0 ? (
-          <div className="device-empty">
-            <SignalIcon />
-            <p>No devices detected.<br />Connect your Android via USB and enable USB debugging.</p>
+        <div className="device-list">
+          <div className="device-list-header">
+            <span className="device-list-title">
+              {devices.length > 0
+                ? `${devices.length} device${devices.length > 1 ? "s" : ""} found`
+                : "Searching..."}
+            </span>
+            <button className="device-list-refresh" onClick={onRefreshDevices}>
+              <ArrowPathIcon /> Refresh
+            </button>
           </div>
-        ) : (
-          devices.map((d) => (
-            <div
-              key={d.serial}
-              className="device-card"
-              onClick={() => !connectingSerial && onConnectDevice(d)}
-              onContextMenu={(e) => handleContextMenu(e, d)}
-            >
-              <div className="device-card-icon">
-                <DevicePhoneMobileIcon />
-              </div>
-              <div className="device-card-info">
-                {editingSerial === d.serial ? (
-                  <input
-                    className="device-nickname-input"
-                    value={editValue}
-                    onChange={(e) => setEditValue(e.target.value)}
-                    onBlur={() => { setDeviceNickname(d.serial, editValue); setEditingSerial(null); }}
-                    onKeyDown={(e) => {
-                      e.stopPropagation();
-                      if (e.key === "Enter") { setDeviceNickname(d.serial, editValue); setEditingSerial(null); }
-                      if (e.key === "Escape") setEditingSerial(null);
-                    }}
-                    onClick={(e) => e.stopPropagation()}
-                    autoFocus
-                  />
-                ) : (
-                  <div
-                    className="device-card-name"
-                    onDoubleClick={(e) => { e.stopPropagation(); setEditingSerial(d.serial); setEditValue(getDeviceDisplayName(d)); }}
-                    title="Double-click to rename"
-                  >
-                    {getDeviceDisplayName(d)}
+
+          {devices.length === 0 ? (
+            <div className="device-empty">
+              <SignalIcon />
+              <p>
+                No devices detected.
+                <br />
+                Connect your Android via USB and enable USB debugging.
+              </p>
+            </div>
+          ) : (
+            devices.map((d) => (
+              <div
+                key={d.serial}
+                className="device-card"
+                onClick={() => !connectingSerial && onConnectDevice(d)}
+                onContextMenu={(e) => handleContextMenu(e, d)}
+              >
+                <div className="device-card-icon">
+                  <DevicePhoneMobileIcon />
+                </div>
+                <div className="device-card-info">
+                  {editingSerial === d.serial ? (
+                    <input
+                      className="device-nickname-input"
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onBlur={() => {
+                        setDeviceNickname(d.serial, editValue);
+                        setEditingSerial(null);
+                      }}
+                      onKeyDown={(e) => {
+                        e.stopPropagation();
+                        if (e.key === "Enter") {
+                          setDeviceNickname(d.serial, editValue);
+                          setEditingSerial(null);
+                        }
+                        if (e.key === "Escape") setEditingSerial(null);
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      autoFocus
+                    />
+                  ) : (
+                    <div
+                      className="device-card-name"
+                      onDoubleClick={(e) => {
+                        e.stopPropagation();
+                        setEditingSerial(d.serial);
+                        setEditValue(getDeviceDisplayName(d));
+                      }}
+                      title="Double-click to rename"
+                    >
+                      {getDeviceDisplayName(d)}
+                    </div>
+                  )}
+                  <div className="device-card-serial">
+                    {truncateSerial(d.serial)}
                   </div>
-                )}
-                <div className="device-card-serial">
-                  {truncateSerial(d.serial)}
+                </div>
+                <div className="device-card-actions">
+                  <button
+                    className={`device-wifi-toggle ${isWifiDevice(d.serial) || d.wifi_available ? "active" : ""}`}
+                    title={
+                      isWifiDevice(d.serial) ? "Disable WiFi" : "Enable WiFi"
+                    }
+                    onClick={(e) => handleToggleWifi(e, d)}
+                    disabled={togglingSerial === d.serial}
+                  >
+                    {togglingSerial === d.serial ? (
+                      <div className="spinner-sm" />
+                    ) : (
+                      <WifiIcon />
+                    )}
+                  </button>
+                  {connectingSerial === d.serial ? (
+                    <div className="spinner-sm" />
+                  ) : (
+                    <ChevronRightIcon className="device-card-chevron" />
+                  )}
                 </div>
               </div>
-              <div className="device-card-actions">
-                <button
-                  className={`device-wifi-toggle ${isWifiDevice(d.serial) || d.wifi_available ? "active" : ""}`}
-                  title={isWifiDevice(d.serial) ? "Disable WiFi" : "Enable WiFi"}
-                  onClick={(e) => handleToggleWifi(e, d)}
-                  disabled={togglingSerial === d.serial}
-                >
-                  {togglingSerial === d.serial ? <div className="spinner-sm" /> : <WifiIcon />}
-                </button>
-                {connectingSerial === d.serial ? <div className="spinner-sm" /> : <ChevronRightIcon className="device-card-chevron" />}
-              </div>
-            </div>
-          ))
-        )}
+            ))
+          )}
+        </div>
       </div>
 
       {contextMenu && (
@@ -210,39 +286,59 @@ export function WelcomeScreen({
           className="context-menu"
           style={{ top: contextMenu.y, left: contextMenu.x }}
         >
-          <button className="context-menu-item" onClick={() => {
-            onConnectDevice(contextMenu.device);
-            setContextMenu(null);
-          }}>
+          <button
+            className="context-menu-item"
+            onClick={() => {
+              onConnectDevice(contextMenu.device);
+              setContextMenu(null);
+            }}
+          >
             Connect
           </button>
-          <button className="context-menu-item" onClick={() => {
-            setEditingSerial(contextMenu.device.serial);
-            setEditValue(getDeviceDisplayName(contextMenu.device));
-            setContextMenu(null);
-          }}>
+          <button
+            className="context-menu-item"
+            onClick={() => {
+              setEditingSerial(contextMenu.device.serial);
+              setEditValue(getDeviceDisplayName(contextMenu.device));
+              setContextMenu(null);
+            }}
+          >
             Rename
           </button>
           {getDeviceNickname(contextMenu.device.serial) && (
-            <button className="context-menu-item" onClick={() => {
-              setDeviceNickname(contextMenu.device.serial, "");
-              setContextMenu(null);
-            }}>
+            <button
+              className="context-menu-item"
+              onClick={() => {
+                setDeviceNickname(contextMenu.device.serial, "");
+                setContextMenu(null);
+              }}
+            >
               Reset Name
             </button>
           )}
-          <button className="context-menu-item" onClick={() => {
-            handleToggleWifi({ stopPropagation: () => {} } as React.MouseEvent, contextMenu.device);
-            setContextMenu(null);
-          }}>
-            {isWifiDevice(contextMenu.device.serial) ? "Disable WiFi" : "Enable WiFi"}
+          <button
+            className="context-menu-item"
+            onClick={() => {
+              handleToggleWifi(
+                { stopPropagation: () => {} } as React.MouseEvent,
+                contextMenu.device
+              );
+              setContextMenu(null);
+            }}
+          >
+            {isWifiDevice(contextMenu.device.serial)
+              ? "Disable WiFi"
+              : "Enable WiFi"}
           </button>
           <div className="context-menu-separator" />
-          <button className="context-menu-item" onClick={() => {
-            navigator.clipboard.writeText(contextMenu.device.serial);
-            showToast("Serial copied", "info");
-            setContextMenu(null);
-          }}>
+          <button
+            className="context-menu-item"
+            onClick={() => {
+              navigator.clipboard.writeText(contextMenu.device.serial);
+              showToast("Serial copied", "info");
+              setContextMenu(null);
+            }}
+          >
             Copy Serial
           </button>
         </div>
@@ -252,10 +348,14 @@ export function WelcomeScreen({
         <Dialog.Portal>
           <Dialog.Backdrop className="dialog-backdrop" />
           <Dialog.Popup className="wifi-dialog">
-            <Dialog.Title className="wifi-dialog-title">Connect by IP</Dialog.Title>
+            <Dialog.Title className="wifi-dialog-title">
+              Connect by IP
+            </Dialog.Title>
             <div className="wifi-dialog-section">
               <p className="wifi-dialog-desc">
-                On your Android device, go to <strong>Settings &gt; About phone &gt; Status</strong> to find your IP address. Both devices must be on the same network.
+                On your Android device, go to{" "}
+                <strong>Settings &gt; About phone &gt; Status</strong> to find
+                your IP address. Both devices must be on the same network.
               </p>
               <div className="wifi-dialog-form">
                 <input


### PR DESCRIPTION
## What this fixes
On macOS, the app window had no drag region, making it impossible 
to move the window around the screen.

## Changes
Added `data-tauri-drag-region` attribute to the toolbar component, 
which Tauri uses to designate draggable areas on windows with 
hidden/overlay title bars.

## Tested on
- macOS (Apple Silicon M1 Pro)
- Built from source using `bun tauri build`

<img width="493" height="928" alt="image" src="https://github.com/user-attachments/assets/3aa22f19-0fb2-4914-8e0f-f1e353f4a48c" />

