### PR TITLE
fix(adb): prevent console window popup on Windows

### DIFF
--- a/crates/another-core/src/adb.rs
+++ b/crates/another-core/src/adb.rs
@@ -51,8 +51,17 @@ fn adb_path() -> PathBuf {
     PathBuf::from(binary)
 }
 
+fn adb_command() -> Command {
+    let mut cmd = Command::new(adb_path());
+    #[cfg(windows)]
+    {
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+    cmd
+}
+
 async fn run_adb(args: &[&str]) -> Result<Vec<u8>> {
-    let output = Command::new(adb_path())
+    let output = adb_command()
         .args(args)
         .output()
         .await
@@ -130,7 +139,7 @@ pub async fn remove_forward(serial: &str, local_port: u16) -> Result<()> {
 }
 
 pub async fn shell(serial: &str, cmd: &str) -> Result<tokio::process::Child> {
-    let child = Command::new(adb_path())
+    let child = adb_command()
         .args(["-s", serial, "shell", cmd])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
## Problem
On Windows, running `adb.exe` subprocesses causes a console window to
flash and steal focus repeatedly, making the app annoying to use.
Closes #17
## Solution
Add a `adb_command()` helper that sets the Windows
`CREATE_NO_WINDOW` creation flag (`0x08000000`) on all spawned adb
processes. This keeps adb running silently in the background.
## Changes
- `crates/another-core/src/adb.rs`: Added `adb_command()` helper and
  replaced direct `Command::new(adb_path())` calls in `run_adb()` and
  `shell()`.
## Testing
- Tested on Windows 11 with a Samsung device via USB.
- adb.exe no longer opens a visible console window.
- All adb operations (devices, shell, forward, push, screencap)
  continue to work normally.